### PR TITLE
use trees api to fetch github data

### DIFF
--- a/code/utils.py
+++ b/code/utils.py
@@ -1,17 +1,44 @@
-import requests
 import os
+import sys
+
+import requests
+
 
 def get_fhi_datafiles(filestr):
     files = []
-    headers = { 'Authorization': 'token ' + os.environ.get('GITHUB_TOKEN') }
+    s = requests.Session()
+    s.headers = {"Authorization": "token " + os.environ.get("GITHUB_TOKEN")}
+    repo = "folkehelseinstituttet/surveillance_data"
+    repo_url = f"https://api.github.com/repos/{repo}"
+    covid19_dir = "covid19"
+    # use trees API to get large list of files
+    # contents API truncates to 1000 files
+    try:
+        # get the sha for the latest commit
+        r = s.get(repo_url + "/git/ref/heads/master")
+        r.raise_for_status()
+        head_sha = r.json()["object"]["sha"]
+        # get tree contents for top-level directory
+        r = s.get(f"{repo_url}/git/trees/{head_sha}")
+        r.raise_for_status()
+        tree_root = r.json()
+        # locate covid19 subdirectory
+        for subtree in tree_root["tree"]:
+            if subtree["path"] == covid19_dir:
+                covidtree_url = subtree["url"]
 
-    contents = requests.get('https://api.github.com/repos/folkehelseinstituttet/surveillance_data/contents/covid19', headers=headers)
-    
-    if contents.status_code == 200:
-        for content in contents.json():
-            if filestr in content['name'] and 'csv' in content['name']:
-                files.append(content['download_url'])
+        # finally, list covid19 directory contents
+        r = requests.get(covidtree_url)
+        r.raise_for_status()
+        blobs = r.json()["tree"]
+    except requests.HTTPException as e:
+        print(f"Error accessing GitHub API: {e}", file=sys.stderr)
     else:
-        print('Error accessing GitHub API.')
+        for blob in blobs:
+            name = blob["path"]
+            if filestr in name and name.endswith(".csv"):
+                # blobs API doesn't include download URL
+                download_url = f"https://raw.githubusercontent.com/{repo}/{head_sha}/{covid19_dir}/{name}"
+                files.append(download_url)
 
     return files


### PR DESCRIPTION
contents api truncates to 1000 files, which means some test data (data/03_covid_tests/national_tests_lab.csv) hasn't been updated since October.

trees api is more tedious, but not truncated. Results of running `code/04_fhi_daily_reports/01_get_number_of_tests.py` can be seen  at https://github.com/minrk/covid19-nor-data/commit/71463609537ac81263f7ea6c683082d242064585 